### PR TITLE
Fix subdomain redirects to only match root path

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -16,7 +16,7 @@
       "permanent": true
     },
     {
-      "source": "/:path*",
+      "source": "/",
       "destination": "https://www.linkedin.com/in/harmanpunn/",
       "has": [
         {
@@ -27,7 +27,7 @@
       "permanent": true
     },
     {
-      "source": "/:path*",
+      "source": "/",
       "destination": "https://github.com/harmanpunn",
       "has": [
         {


### PR DESCRIPTION
- Change from /:path* to / to only redirect root requests
- Prevents assets (CSS/JS) from being redirected
- Fixes CORS errors caused by asset redirects

