### PR TITLE
Fix: Remove leading whitespace from sitemap.xml

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>


### PR DESCRIPTION
Fixed XML declaration error by ensuring it starts at the very beginning of the document without any leading empty lines.

